### PR TITLE
Adding content type to header

### DIFF
--- a/src/components/HelloWorld.vue
+++ b/src/components/HelloWorld.vue
@@ -22,6 +22,9 @@ var leaveUrl = 'http://localhost:5173/'
 function getSignature() {
   fetch(authEndpoint, {
     method: 'POST',
+    headers: {
+    'Content-Type': 'application/json', // Specify the content type as JSON
+    },
     body: JSON.stringify({
       meetingNumber: meetingNumber,
       role: role


### PR DESCRIPTION
added header in HTTP POST to specify content-type as application/json
this will help to handle edge cases where the server side signature generation does not recognize the payload as application/json